### PR TITLE
Bump vulnerable transitive deps to 8.0.27 (stay on .NET 8 LTS)

### DIFF
--- a/src/AspNetIdentity/host/Host.csproj
+++ b/src/AspNetIdentity/host/Host.csproj
@@ -9,11 +9,14 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <!-- Pin transitive System.Text.Json to a patched version (GHSA-hh2w-p6rv-4g7w, GHSA-8g4q-xg66-9fp4);
+         Serilog floors it at the vulnerable 8.0.0. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     
     <ProjectReference Include="..\src\Ourstudio.IdentityServer.AspNetIdentity.csproj" />

--- a/src/EntityFramework.Storage/host/ConsoleHost/ConsoleHost.csproj
+++ b/src/EntityFramework.Storage/host/ConsoleHost/ConsoleHost.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFramework.Storage/migrations/SqlServer/SqlServer.csproj
+++ b/src/EntityFramework.Storage/migrations/SqlServer/SqlServer.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="All" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
     <ProjectReference Include="..\..\src\Ourstudio.IdentityServer.EntityFramework.Storage.csproj" />
   </ItemGroup>
   

--- a/src/EntityFramework.Storage/src/Ourstudio.IdentityServer.EntityFramework.Storage.csproj
+++ b/src/EntityFramework.Storage/src/Ourstudio.IdentityServer.EntityFramework.Storage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Ourstudio.IdentityServer.EntityFramework.Storage</PackageId>
@@ -29,9 +29,9 @@
         <NoWarn>NU1604</NoWarn>
     </PackageReference>
     
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.27" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.27" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/Ourstudio.IdentityServer.EntityFramework.IntegrationTests.csproj
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Ourstudio.IdentityServer.EntityFramework.IntegrationTests.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
 
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/EntityFramework.Storage/test/UnitTests/Ourstudio.IdentityServer.EntityFramework.UnitTests.csproj
+++ b/src/EntityFramework.Storage/test/UnitTests/Ourstudio.IdentityServer.EntityFramework.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
 
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/EntityFramework/host/Host.csproj
+++ b/src/EntityFramework/host/Host.csproj
@@ -8,12 +8,15 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <!-- Pin transitive System.Text.Json to a patched version (GHSA-hh2w-p6rv-4g7w, GHSA-8g4q-xg66-9fp4);
+         Serilog floors it at the vulnerable 8.0.0. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Ourstudio.IdentityServer.EntityFramework.csproj" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/EntityFramework/migrations/SqlServer/SqlServer.csproj
+++ b/src/EntityFramework/migrations/SqlServer/SqlServer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ourstudio.IdentityServer.EntityFramework.csproj" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
   </ItemGroup>
 
 </Project>

--- a/src/EntityFramework/test/Ourstudio.IdentityServer.EntityFramework.Tests/Ourstudio.IdentityServer.EntityFramework.Tests.csproj
+++ b/src/EntityFramework/test/Ourstudio.IdentityServer.EntityFramework.Tests/Ourstudio.IdentityServer.EntityFramework.Tests.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
   
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
 
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/IdentityServer/host/Host.csproj
+++ b/src/IdentityServer/host/Host.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.27" />
     
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="All" Version="8.0.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     

--- a/src/IdentityServer/src/Ourstudio.IdentityServer.csproj
+++ b/src/IdentityServer/src/Ourstudio.IdentityServer.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.2.0" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.27" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />

--- a/src/IdentityServer/test/Ourstudio.IdentityServer.IntegrationTests/Ourstudio.IdentityServer.IntegrationTests.csproj
+++ b/src/IdentityServer/test/Ourstudio.IdentityServer.IntegrationTests/Ourstudio.IdentityServer.IntegrationTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     
     <PackageReference Include="xunit" Version="2.6.5" />

--- a/src/RedisStore/test/Ourstudio.IdentityServer.RedisStore.Tests/Ourstudio.IdentityServer.RedisStore.Tests.csproj
+++ b/src/RedisStore/test/Ourstudio.IdentityServer.RedisStore.Tests/Ourstudio.IdentityServer.RedisStore.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="FluentAssertions" Version="6.12.*" />
     <PackageReference Include="IdentityModel" Version="6.2.0" />
     <PackageReference Include="Ourstudio.IdentityServer" Version="*-*" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.6.5" />
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
 
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
## Why
`dotnet list package --vulnerable` flags **5 transitive vulnerabilities**, all driven by the pinned `Microsoft.EntityFrameworkCore.* 8.0.1` (Mar 2024) and the SqlServer→SqlClient chain it drags in:

| Package | Resolved | Severity | Advisory |
|---|---|---|---|
| Microsoft.Extensions.Caching.Memory | 8.0.0 | High | GHSA-qj66-m88j-hmgj |
| Microsoft.Data.SqlClient | 5.1.1 | High | GHSA-98g6-xh36-x2p7 |
| Azure.Identity | 1.7.0 | High (+2 mod) | GHSA-5mfx-4wcx-rv27 |
| System.Formats.Asn1 | 5.0.0 | High | GHSA-447r-wph3-92pm |
| System.Text.Json | 8.0.0 | High ×2 | GHSA-hh2w-p6rv-4g7w, GHSA-8g4q-xg66-9fp4 |

The published `*.EntityFramework.Storage` / `*.EntityFramework` packages carry the `Caching.Memory` one; the SqlClient chain shows up in hosts/migrations/tests.

## What
Bump within the **8.0 LTS** line — no major-version jump:
- `Microsoft.EntityFrameworkCore.*` + `Microsoft.AspNetCore.*`: `8.0.1 → 8.0.27` (cascades patched SqlClient → fixed Azure.Identity + System.Formats.Asn1, and fixed System.Text.Json / Caching.Memory transitively).
- `Microsoft.Extensions.Caching.Memory` / `Configuration.Json`: `8.0.0 → 8.0.1`.
- Pin `System.Text.Json 8.0.6` explicitly in the two sample hosts, where Serilog floors it at the vulnerable 8.0.0.

`dotnet list package --vulnerable` is now **clean** across all projects (except AutoMapper — removed in #14).

## Verification
- EF.Storage unit **16/16**, integration **80/80** (InMemory + SQLite), EntityFramework **4/4** — green.
- IdentityServer unit/integration pass counts **unchanged vs baseline** — the bump introduces zero new failures.

### Out of scope (pre-existing on `main`)
1 unit + 11 `JwtRequestAuthorizeTests` already fail on untouched `main` with `IDX10805` (Microsoft.IdentityModel 7.2.0 ↔ System.Text.Json JsonWebKey deserialization). Not introduced or addressed here — would need a separate IdentityModel bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)